### PR TITLE
Strict naming instead of loose (to prevent naming collision when using NamedRouteLink).

### DIFF
--- a/modules/index.js
+++ b/modules/index.js
@@ -17,19 +17,15 @@ const namedRoutesContextType = {
   }).isRequired
 }
 
-const createRouteMap = (routes, accumulatedPath='', map={}) => {
-  React.Children.forEach(routes, (route) => {
-    const slash = accumulatedPath === '/' ? '' : '/'
-    // can't type check because we might have a different IndexRoute in node_modules
-    const isIndexRoute = route.type.displayName === 'IndexRoute'
-    const path = isIndexRoute ? accumulatedPath :
-      route.props.path === '/' ?
-        '/' : `${accumulatedPath}${slash}${route.props.path}`
-    if (route.props.name)
-      map[route.props.name] = path
-    if (route.props.children)
-      createRouteMap(route.props.children, path, map)
+const createRouteMap = (route, parentName, parentPath, map = {}) => {
+  map       = handleExtractRouteName(route, parentName, parentPath, map)
+  let routeName = getRouteName(route, parentName)
+  let routePath = getRoutePath(route, parentPath)
+
+  React.Children.forEach(route.props.children, (child) => {
+    map = createRouteMap(child, routeName, routePath, map)
   })
+
   return map
 }
 
@@ -81,3 +77,60 @@ export const NamedRouteLink = React.createClass({
 
 })
 
+/**
+ * @param route
+ * @param parentName
+ * @returns {any}
+ */
+function getRouteName(route, parentName) {
+  if ( !route.props.path && !route.props.name ) {
+    return parentName
+  }
+
+  let routeName = route.props.name || route.props.path
+
+  if ( !routeName ) {
+    return parentName
+  }
+
+  validateRouteName(routeName)
+  return parentName ? parentName + '.' + routeName : routeName
+}
+
+/**
+ * @param route
+ * @param parentPath
+ * @returns {any}
+ */
+function getRoutePath(route, parentPath) {
+  if ( !route.props.path ) {
+    return parentPath
+  }
+
+  return (parentPath ? parentPath + '/' + route.props.path : route.props.path).replace('//', '/')
+}
+
+/**
+ * @param name
+ */
+function validateRouteName(name) {
+  if ( name.indexOf(':') !== -1 || name.indexOf('*') !== -1 || name.indexOf('/') !== -1 ) {
+    if ( process.env.NODE_ENV !== 'production' ) {
+      throw new Error('Invalid route name. The route with name ' + name + ' contains parameters (since it contains ":", "*" or "/" thus the name is invalid. Please check this route.')
+    } else {
+      throw new Error('Invalid route name "' + name + '". Please compile for "development" to see the full error message')
+    }
+  }
+}
+
+function handleExtractRouteName(route, parentName, parentPath, map) {
+  let routeName = getRouteName(route, parentName)
+  let routePath = getRoutePath(route, parentPath)
+
+  if ( !routeName ) {
+    return map
+  }
+
+  map[ routeName ] = routePath
+  return map
+}

--- a/modules/index.test.js
+++ b/modules/index.test.js
@@ -27,7 +27,7 @@ describe('NamedRoutes', () => {
     const Index = () => <div>Index</div>
 
     const routes = (
-      <Route path="/" component={Container}>
+      <Route path="/" name="base" component={Container}>
         <IndexRoute name="index" component={Index}/>
         <Route name="parent" path="p" component={Parent}>
           <Route name="reference" path="r" component={Reference}>
@@ -50,21 +50,21 @@ describe('NamedRoutes', () => {
   }
 
   it('links to routes by name', (done) => {
-    run(<NamedRouteLink to="parent"/>, '/p/r', (node) => {
+    run(<NamedRouteLink to="base.parent"/>, '/p/r', (node) => {
       expect(node.getAttribute('href')).toEqual('/p')
       done()
     })
   })
 
   it('works with index routes', (done) => {
-    run(<NamedRouteLink to="index"/>, '/p/r', (node) => {
+    run(<NamedRouteLink to="base.index"/>, '/p/r', (node) => {
       expect(node.getAttribute('href')).toEqual('/')
       done()
     })
   })
 
   it('injects params', (done) => {
-    run(<NamedRouteLink to="child" params={{ param: 'test' }}/>, '/p/r', (node) => {
+    run(<NamedRouteLink to="base.parent.reference.child" params={{ param: 'test' }}/>, '/p/r', (node) => {
       expect(node.getAttribute('href')).toEqual('/p/r/c/test')
       done()
     })


### PR DESCRIPTION
- Allows strict nesting via [parent].[name] notation. This way you can have routes with the same name and not collide with each other. The
  downside is that your main route (the "/" base route) needs to have a
  name.
- Allows auto route names based on path if no name is present on a route.
- Validation of names not to contain slashes or parameters, because
  a route name can be based on its path.
